### PR TITLE
feat: add markdown issue templates and enforce conventional commits

### DIFF
--- a/.github/ISSUE_TEMPLATE/Bug Report Template.md
+++ b/.github/ISSUE_TEMPLATE/Bug Report Template.md
@@ -1,0 +1,50 @@
+---
+name: "🐛 Bug Report"
+description: "Report a bug or unexpected behavior"
+title: "[Bug]: "
+labels: ["bug", "triage"]
+projects: [5]
+assignees: []
+---
+
+## 🐛 Bug Report
+
+Thanks for taking the time to report a bug! Please fill out the form below to help us understand and reproduce the issue.
+
+### Describe the bug
+
+A clear and concise description of what the bug is.
+
+### Steps to reproduce
+
+Steps to reproduce the behavior:
+
+1. Go to '...'
+2. Click on '....'
+3. Scroll down to '....'
+4. See error
+
+### Expected behavior
+
+A clear and concise description of what you expected to happen.
+
+### Actual behavior
+
+What actually happened?
+
+### Environment
+
+- **OS**: [e.g., macOS 14.0, Ubuntu 22.04, Windows 11]
+- **Node.js version**: [e.g., v18.17.0]
+- **better-agents version**: [e.g., v1.0.0]
+
+### Additional context
+
+Add any other context about the problem here (screenshots, logs, etc.).
+
+### Checklist
+
+- [ ] I have searched for existing issues to avoid duplicates
+- [ ] I have tried the latest version of better-agents
+- [ ] I have provided a minimal reproduction case
+- [ ] I have included relevant logs and error messages

--- a/.github/ISSUE_TEMPLATE/Documentation Template.md
+++ b/.github/ISSUE_TEMPLATE/Documentation Template.md
@@ -1,0 +1,50 @@
+---
+name: "📚 Documentation Issue"
+description: "Report issues with documentation"
+title: "[Docs]: "
+labels: ["documentation", "triage"]
+projects: [5]
+assignees: []
+---
+
+## 📚 Documentation Issue
+
+Help us improve our documentation! Please report any issues, missing information, or unclear content.
+
+### Documentation Issue Type
+
+What type of documentation issue is this?
+
+- [ ] Missing documentation
+- [ ] Outdated information
+- [ ] Unclear or confusing content
+- [ ] Incorrect information
+- [ ] Formatting/typo
+- [ ] Broken links
+- [ ] Other
+
+### Page URL
+
+The URL of the documentation page (if applicable)
+
+### Section/File
+
+Which section or file has the issue?
+
+### Description
+
+Describe the documentation issue in detail.
+
+### Suggested Fix
+
+How would you fix this documentation issue?
+
+### Additional Context
+
+Any additional context about this documentation issue.
+
+### Checklist
+
+- [ ] I have searched existing documentation issues to avoid duplicates
+- [ ] The issue is with official documentation (not user-generated content)
+- [ ] I am willing to help fix this documentation issue

--- a/.github/ISSUE_TEMPLATE/Feature Request Template.md
+++ b/.github/ISSUE_TEMPLATE/Feature Request Template.md
@@ -1,0 +1,57 @@
+---
+name: "✨ Feature Request"
+description: "Suggest a new feature or enhancement"
+title: "[Feature]: "
+labels: ["enhancement", "triage"]
+projects: [5]
+assignees: []
+---
+
+## ✨ Feature Request
+
+Thanks for suggesting a new feature! Your ideas help make better-agents better for everyone.
+
+### Feature Summary
+
+Provide a brief summary of the feature you'd like to see.
+
+### Problem/Use Case
+
+What problem does this feature solve? What's the use case?
+
+### Proposed Solution
+
+Describe how you envision this feature working.
+
+### Alternative Solutions
+
+Describe any alternative solutions or features you've considered.
+
+### Priority
+
+How important is this feature to you?
+
+- [ ] Nice to have
+- [ ] Would be helpful
+- [ ] Important for my use case
+- [ ] Critical/Blocking
+
+### Estimated Complexity
+
+How complex do you think this feature would be to implement?
+
+- [ ] Simple (small change)
+- [ ] Medium (moderate changes)
+- [ ] Complex (significant changes)
+- [ ] Very Complex (architectural changes)
+
+### Additional Context
+
+Any additional context, screenshots, or examples.
+
+### Checklist
+
+- [ ] I have searched for existing feature requests to avoid duplicates
+- [ ] This feature would benefit other users, not just me
+- [ ] I am willing to help implement this feature
+- [ ] I can provide more details if needed

--- a/.github/ISSUE_TEMPLATE/Question Template.md
+++ b/.github/ISSUE_TEMPLATE/Question Template.md
@@ -1,0 +1,62 @@
+---
+name: "❓ Question/Support"
+description: "Ask a question or request help"
+title: "[Question]: "
+labels: ["question", "triage"]
+projects: [5]
+assignees: []
+---
+
+## ❓ Question/Support
+
+Have a question about better-agents? Need help getting started or troubleshooting? Ask away!
+
+**Note:** If you found a bug or want to suggest a feature, please use the appropriate issue templates instead.
+
+### Question Category
+
+What type of question do you have?
+
+- [ ] Getting Started / Setup
+- [ ] Usage / How-to
+- [ ] Configuration
+- [ ] Troubleshooting
+- [ ] Integration
+- [ ] Best Practices
+- [ ] General
+
+### Your Question
+
+What would you like to know?
+
+### Context
+
+Provide context about your situation.
+
+- What are you trying to accomplish?
+- What have you tried so far?
+- What's your environment/setup?
+
+### Code Example (if applicable)
+
+```typescript
+// Your code here
+```
+
+### better-agents Version
+
+[e.g., v1.0.0]
+
+### Environment
+
+Your environment details (OS, Node version, etc.) [e.g., macOS 14.0, Node.js v18.17.0]
+
+### Additional Information
+
+Any other information that might be helpful. (Logs, error messages, screenshots, etc.)
+
+### Checklist
+
+- [ ] I have searched existing questions/issues to avoid duplicates
+- [ ] I have checked the documentation for answers
+- [ ] This is not a bug report or feature request

--- a/.github/workflows/issue-link.yml
+++ b/.github/workflows/issue-link.yml
@@ -1,0 +1,21 @@
+name: 'Issue Links'
+on:
+  pull_request:
+    types: [opened]
+
+jobs:
+  issue-links:
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
+      issues: write
+    steps:
+      - uses: tkt-actions/add-issue-links@v1.9.1
+        with:
+          repo-token: '${{ secrets.GITHUB_TOKEN }}'
+          branch-prefix: 'issue'
+          link-style: 'body'
+          position: 'body'
+          header: '# Related Issue'
+          resolve: true
+          assign-pr-creator-to-issue: 'true'

--- a/.github/workflows/pr-conventional-commits-title.yml
+++ b/.github/workflows/pr-conventional-commits-title.yml
@@ -1,0 +1,65 @@
+name: pr-conventions
+
+on:
+  pull_request:
+    types: [opened, edited, synchronize, reopened]
+
+permissions:
+  pull-requests: read
+  statuses: write
+
+jobs:
+  check-pr-title:
+    name: validate title
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check PR Title
+        uses: amannn/action-semantic-pull-request@v5
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          # Configure which types are allowed (default from conventional commits)
+          types: |
+            feat
+            fix
+            docs
+            style
+            refactor
+            perf
+            test
+            build
+            ci
+            chore
+            revert
+          # Configure which scopes are allowed.
+          # scopes: |
+          #   core
+          #   ui
+          # Configure whether a scope is required.
+          requireScope: false
+          # Configure additional validation for the subject based on a regex.
+          # This example ensures the subject doesn't start with an uppercase character.
+          subjectPattern: ^(?![A-Z]).+$
+          # If `subjectPattern` is configured, you can use this property to override
+          # the default error message that is shown when the pattern doesn't match.
+          # The variables `subject` and `title` can be used within the message.
+          subjectPatternError: |
+            The subject "{subject}" found in the pull request title "{title}"
+            didn't match the configured pattern. Please ensure that the subject
+            doesn't start with an uppercase character.
+          # If the PR contains one of these labels, the validation is skipped.
+          # Multiple labels can be separated by newlines.
+          # ignoreLabels: |
+          #   bot
+          # For work-in-progress PRs, you can typically use draft pull requests
+          # from GitHub. However, private repositories on the free plan don't have
+          # this option and therefore this action allows you to opt-in to using the
+          # special "[WIP]" prefix to indicate this state. This will avoid the
+          # validation of the PR title and the pull request checks remain pending.
+          # Note that a second check will be reported if this is enabled.
+          wip: true
+          # When using "Squash and merge" on a PR with only one commit, GitHub
+          # will suggest using that commit message instead of the PR title for the
+          # merge commit, and it's easy to commit this by mistake. Enable this option
+          # to also validate the commit message for one-commit PRs.
+          validateSingleCommit: false

--- a/commitlint.config.js
+++ b/commitlint.config.js
@@ -26,5 +26,6 @@ export default {
     "subject-empty": [2, "never"],
     "subject-full-stop": [2, "never", "."],
     "header-max-length": [2, "always", 100],
+    "references-empty": [2, "never"],
   },
 };


### PR DESCRIPTION
- Add markdown versions of all issue templates (Bug Report, Feature Request, Question, Documentation)
- Enforce issue references in commit messages via commitlint
- Create separate workflows for commit linting and issue linking
- Remove commit linting from main CI workflow for better separation

Closes #23
Closes #24 

# Related Issue

- Resolve #23