### PR TITLE
feat: add non-interactive mode with CLI options

### DIFF
--- a/src/commands/init.ts
+++ b/src/commands/init.ts
@@ -10,7 +10,7 @@ import { setupEditorConfigs } from "../builders/editor-setup-builder.js";
 import { setupAntigravityMCPConfig } from "../providers/coding-assistants/antigravity/index.js";
 import { kickoffAssistant } from "../assistant-kickoff/kickoff-assistant.js";
 import { LoggerFacade } from "../utils/logger/logger-facade.js";
-import type { ProjectConfig } from "../types.js";
+import type { ProjectConfig, CLIOptions } from "../types.js";
 
 /**
  * Displays a static banner with ASCII art
@@ -42,16 +42,22 @@ const showBanner = (): void => {
  * Initializes a new agent project with best practices.
  *
  * @param targetPath - Path where the project should be created (relative to cwd)
+ * @param cliOptions - CLI options for non-interactive mode
  * @param debug - Whether to enable debug logging
  * @returns Promise that resolves when initialization is complete
  *
  * @example
  * ```ts
  * await initCommand('my-agent-project');
- * await initCommand('my-agent-project', true); // with debug logging
+ * await initCommand('my-agent-project', {}, true); // with debug logging
+ * await initCommand('my-agent-project', { language: 'python', framework: 'agno', ... }, false); // non-interactive
  * ```
  */
-export const initCommand = async (targetPath: string, debug = false): Promise<void> => {
+export const initCommand = async (
+  targetPath: string,
+  cliOptions: CLIOptions = {},
+  debug = false
+): Promise<void> => {
   // Set debug environment variable for logger detection
   if (debug) {
     process.env.SUPERAGENTS_DEBUG = 'true';
@@ -61,11 +67,13 @@ export const initCommand = async (targetPath: string, debug = false): Promise<vo
   const logger = new LoggerFacade();
 
   try {
-    // Show banner
-    showBanner();
+    // Show banner (skip in fully non-interactive mode for cleaner output)
+    if (!cliOptions.yes) {
+      showBanner();
+    }
 
     const configTimer = logger.startTimer('config-collection');
-    const config: ProjectConfig = await collectConfig();
+    const config: ProjectConfig = await collectConfig(cliOptions);
     configTimer();
 
     const absolutePath = path.resolve(process.cwd(), targetPath);

--- a/src/config-collection/collect-config.ts
+++ b/src/config-collection/collect-config.ts
@@ -5,6 +5,8 @@ import type {
   AgentFramework,
   CodingAssistant,
   LLMProvider,
+  ProgrammingLanguage,
+  CLIOptions,
 } from "../types.js";
 import { logger } from "../utils/logger/index.js";
 import { buildLanguageChoices } from "./choice-builders/language-choices.js";
@@ -17,34 +19,143 @@ import { validateLangWatchKey } from "./validators/langwatch-key.js";
 import { validateProjectGoal } from "./validators/project-goal.js";
 
 /**
- * Collects project configuration from user via interactive CLI prompts.
+ * Validates that all required options are provided for non-interactive mode.
+ * @param options - CLI options to validate
+ * @throws Error if required options are missing
+ */
+const validateNonInteractiveOptions = (options: CLIOptions): void => {
+  const missing: string[] = [];
+
+  if (!options.language) missing.push("--language");
+  if (!options.framework) missing.push("--framework");
+  if (!options.llmProvider) missing.push("--llm-provider");
+  if (!options.llmKey) missing.push("--llm-key");
+  if (!options.langwatchKey) missing.push("--langwatch-key");
+  if (!options.codingAssistant) missing.push("--coding-assistant");
+  if (!options.goal) missing.push("--goal");
+
+  // Check for Bedrock-specific requirements
+  if (options.llmProvider === "bedrock") {
+    if (!options.awsSecretKey) missing.push("--aws-secret-key");
+    if (!options.awsRegion) missing.push("--aws-region");
+  }
+
+  if (missing.length > 0) {
+    throw new Error(
+      `Non-interactive mode (--yes) requires all options. Missing: ${missing.join(", ")}`
+    );
+  }
+};
+
+/**
+ * Validates framework is compatible with language.
+ * @param language - Selected programming language
+ * @param framework - Selected framework
+ * @throws Error if framework is incompatible with language
+ */
+const validateFrameworkLanguage = (
+  language: ProgrammingLanguage,
+  framework: AgentFramework
+): void => {
+  const pythonFrameworks: AgentFramework[] = ["agno", "langgraph-py"];
+  const typescriptFrameworks: AgentFramework[] = ["mastra", "langgraph-ts"];
+
+  if (language === "python" && !pythonFrameworks.includes(framework)) {
+    throw new Error(
+      `Framework "${framework}" is not compatible with Python. Use: ${pythonFrameworks.join(", ")}`
+    );
+  }
+
+  if (language === "typescript" && !typescriptFrameworks.includes(framework)) {
+    throw new Error(
+      `Framework "${framework}" is not compatible with TypeScript. Use: ${typescriptFrameworks.join(", ")}`
+    );
+  }
+};
+
+/**
+ * Collects project configuration from user via interactive CLI prompts,
+ * or uses provided CLI options for non-interactive mode.
  *
+ * @param cliOptions - Optional CLI options for non-interactive mode
  * @returns Promise resolving to complete ProjectConfig
  *
  * @example
  * ```ts
+ * // Interactive mode
  * const config = await collectConfig();
- * // Returns: { language: 'python', framework: 'agno', ... }
+ *
+ * // Non-interactive mode
+ * const config = await collectConfig({
+ *   language: 'python',
+ *   framework: 'agno',
+ *   llmProvider: 'anthropic',
+ *   llmKey: 'sk-ant-...',
+ *   langwatchKey: 'sk-lw-...',
+ *   codingAssistant: 'claude-code',
+ *   goal: 'Build an agent that...',
+ *   yes: true
+ * });
  * ```
  */
-export const collectConfig = async (): Promise<ProjectConfig> => {
+export const collectConfig = async (
+  cliOptions: CLIOptions = {}
+): Promise<ProjectConfig> => {
   try {
+    // If --yes flag is set, validate all required options are provided
+    if (cliOptions.yes) {
+      validateNonInteractiveOptions(cliOptions);
+
+      // Validate framework/language compatibility
+      validateFrameworkLanguage(cliOptions.language!, cliOptions.framework!);
+
+      // Build additional inputs for providers that need them (e.g., Bedrock)
+      let llmAdditionalInputs: Record<string, string> | undefined;
+      if (cliOptions.llmProvider === "bedrock") {
+        llmAdditionalInputs = {
+          awsSecretKey: cliOptions.awsSecretKey!,
+          awsRegion: cliOptions.awsRegion!,
+        };
+      }
+
+      // Return config directly without prompts
+      return {
+        language: cliOptions.language!,
+        framework: cliOptions.framework!,
+        codingAssistant: cliOptions.codingAssistant!,
+        llmProvider: cliOptions.llmProvider!,
+        llmApiKey: cliOptions.llmKey!,
+        llmAdditionalInputs,
+        langwatchApiKey: cliOptions.langwatchKey!,
+        projectGoal: cliOptions.goal!,
+      };
+    }
+
+    // Interactive mode - prompt for missing values
     logger.userInfo(
       "Setting up your agent project following the Better Agent Structure.\n"
     );
 
-    const language = await select({
+    // Language - use CLI option or prompt
+    const language: ProgrammingLanguage = cliOptions.language || await select({
       message: "What programming language do you want to use?",
       choices: buildLanguageChoices(),
     });
 
-    const framework = await select<AgentFramework>({
+    // Framework - use CLI option or prompt
+    const framework: AgentFramework = cliOptions.framework || await select<AgentFramework>({
       message: "What agent framework do you want to use?",
       choices: buildFrameworkChoices({ language }),
     });
 
+    // Validate if both were provided via CLI
+    if (cliOptions.language && cliOptions.framework) {
+      validateFrameworkLanguage(language, framework);
+    }
+
+    // LLM Provider - use CLI option or prompt
     const allProviders = getAllLLMProviders();
-    const llmProvider = await select<LLMProvider>({
+    const llmProvider: LLMProvider = cliOptions.llmProvider || await select<LLMProvider>({
       message: "What LLM provider is your agent going to use?",
       choices: allProviders.map((p) => ({
         name: p.displayName,
@@ -55,24 +166,30 @@ export const collectConfig = async (): Promise<ProjectConfig> => {
     const selectedProvider = allProviders.find((p) => p.id === llmProvider);
     const providerDisplayName = selectedProvider?.displayName || llmProvider;
 
-    if (selectedProvider?.apiKeyUrl) {
-      logger.userInfo(`To get your ${providerDisplayName} API key, visit:`);
-      logger.userInfo(`${selectedProvider.apiKeyUrl}`);
-    }
+    // LLM API Key - use CLI option or prompt
+    let llmApiKey: string;
+    if (cliOptions.llmKey) {
+      llmApiKey = cliOptions.llmKey;
+    } else {
+      if (selectedProvider?.apiKeyUrl) {
+        logger.userInfo(`To get your ${providerDisplayName} API key, visit:`);
+        logger.userInfo(`${selectedProvider.apiKeyUrl}`);
+      }
 
-    const llmApiKey = await password({
-      message: `Enter your ${providerDisplayName} API key:`,
-      mask: "*",
-      validate:
-        llmProvider === "openai"
-          ? validateOpenAIKey
-          : (value) => {
-              if (!value || value.length < 5) {
-                return "API key is required and must be at least 5 characters";
-              }
-              return true;
-            },
-    });
+      llmApiKey = await password({
+        message: `Enter your ${providerDisplayName} API key:`,
+        mask: "*",
+        validate:
+          llmProvider === "openai"
+            ? validateOpenAIKey
+            : (value) => {
+                if (!value || value.length < 5) {
+                  return "API key is required and must be at least 5 characters";
+                }
+                return true;
+              },
+      });
+    }
 
     // Collect additional credentials if the provider needs them
     let llmAdditionalInputs: Record<string, string> | undefined;
@@ -83,6 +200,17 @@ export const collectConfig = async (): Promise<ProjectConfig> => {
       llmAdditionalInputs = {};
 
       for (const credential of selectedProvider.additionalCredentials) {
+        // Check if value was provided via CLI (for Bedrock)
+        if (credential.key === "awsSecretKey" && cliOptions.awsSecretKey) {
+          llmAdditionalInputs[credential.key] = cliOptions.awsSecretKey;
+          continue;
+        }
+        if (credential.key === "awsRegion" && cliOptions.awsRegion) {
+          llmAdditionalInputs[credential.key] = cliOptions.awsRegion;
+          continue;
+        }
+
+        // Otherwise prompt
         if (credential.type === "password") {
           llmAdditionalInputs[credential.key] = await password({
             message: `Enter your ${credential.label}:`,
@@ -99,90 +227,98 @@ export const collectConfig = async (): Promise<ProjectConfig> => {
       }
     }
 
-    const codingAssistant = await select<CodingAssistant>({
+    // Coding Assistant - use CLI option or prompt
+    const codingAssistant: CodingAssistant = cliOptions.codingAssistant || await select<CodingAssistant>({
       message:
         "What is your preferred coding assistant for building the agent?",
       choices: await buildCodingAssistantChoices(),
     });
 
-    // Check if the selected coding assistant is available
-    const codingAssistantProviders = getAllCodingAssistants();
-    const selectedCodingProvider = codingAssistantProviders.find(
-      (p) => p.id === codingAssistant
-    );
+    // Check if the selected coding assistant is available (skip in non-interactive parts)
+    if (!cliOptions.codingAssistant) {
+      const codingAssistantProviders = getAllCodingAssistants();
+      const selectedCodingProvider = codingAssistantProviders.find(
+        (p) => p.id === codingAssistant
+      );
 
-    if (selectedCodingProvider) {
-      let availability = await selectedCodingProvider.isAvailable();
-      if (!availability.installed && availability.installCommand) {
-        logger.userWarning(
-          `${selectedCodingProvider.displayName} is not installed.`
-        );
-        logger.userInfo(`To install it, run:`);
-        logger.userInfo(`${availability.installCommand}`);
+      if (selectedCodingProvider) {
+        let availability = await selectedCodingProvider.isAvailable();
+        if (!availability.installed && availability.installCommand) {
+          logger.userWarning(
+            `${selectedCodingProvider.displayName} is not installed.`
+          );
+          logger.userInfo(`To install it, run:`);
+          logger.userInfo(`${availability.installCommand}`);
 
-        const shouldInstall = await confirm({
-          message: "Would you like me to install it for you?",
-          default: true,
-        });
+          const shouldInstall = await confirm({
+            message: "Would you like me to install it for you?",
+            default: true,
+          });
 
-        if (shouldInstall) {
-          logger.userInfo("Installing...");
-          try {
-            await new Promise<void>((resolve, reject) => {
-              const [cmd, ...args] = availability.installCommand!.split(" ");
-              const child = spawn(cmd, args, { stdio: "inherit" });
+          if (shouldInstall) {
+            logger.userInfo("Installing...");
+            try {
+              await new Promise<void>((resolve, reject) => {
+                const [cmd, ...args] = availability.installCommand!.split(" ");
+                const child = spawn(cmd, args, { stdio: "inherit" });
 
-              child.on("close", (code: number) => {
-                if (code === 0) {
-                  resolve();
-                } else {
-                  reject(
-                    new Error(`Installation failed with exit code ${code}`)
-                  );
-                }
+                child.on("close", (code: number) => {
+                  if (code === 0) {
+                    resolve();
+                  } else {
+                    reject(
+                      new Error(`Installation failed with exit code ${code}`)
+                    );
+                  }
+                });
+
+                child.on("error", reject);
               });
 
-              child.on("error", reject);
-            });
-
-            // Check availability again after installation
-            availability = await selectedCodingProvider.isAvailable();
-            if (availability.installed) {
-              logger.userSuccess(
-                `${selectedCodingProvider.displayName} installed successfully!`
-              );
-            } else {
+              // Check availability again after installation
+              availability = await selectedCodingProvider.isAvailable();
+              if (availability.installed) {
+                logger.userSuccess(
+                  `${selectedCodingProvider.displayName} installed successfully!`
+                );
+              } else {
+                logger.userError(
+                  "Installation may have failed. Please try installing manually."
+                );
+              }
+            } catch (error) {
               logger.userError(
-                "Installation may have failed. Please try installing manually."
+                `Installation failed: ${
+                  error instanceof Error ? error.message : "Unknown error"
+                }`
               );
+              logger.userInfo("Please try installing manually.");
             }
-          } catch (error) {
-            logger.userError(
-              `Installation failed: ${
-                error instanceof Error ? error.message : "Unknown error"
-              }`
-            );
-            logger.userInfo("Please try installing manually.");
           }
-        } else {
-          // Empty line for spacing - no logging needed
         }
       }
+
+      logger.userInfo("✔︎ Your coding assistant will finish setup later if needed\n");
     }
 
-    logger.userInfo("✔︎ Your coding assistant will finish setup later if needed\n");
+    // LangWatch API Key - use CLI option or prompt
+    let langwatchApiKey: string;
+    if (cliOptions.langwatchKey) {
+      langwatchApiKey = cliOptions.langwatchKey;
+    } else {
+      logger.userInfo("To get your LangWatch API key, visit:");
+      logger.userInfo("https://app.langwatch.ai/authorize");
 
-    logger.userInfo("To get your LangWatch API key, visit:");
-    logger.userInfo("https://app.langwatch.ai/authorize");
+      langwatchApiKey = await password({
+        message:
+          "Enter your LangWatch API key (for prompt management, scenarios, evaluations and observability):",
+        mask: "*",
+        validate: validateLangWatchKey,
+      });
+    }
 
-    const langwatchApiKey = await password({
-      message:
-        "Enter your LangWatch API key (for prompt management, scenarios, evaluations and observability):",
-      mask: "*",
-      validate: validateLangWatchKey,
-    });
-
-    const projectGoal = await input({
+    // Project Goal - use CLI option or prompt
+    const projectGoal: string = cliOptions.goal || await input({
       message: "What is your agent going to do?",
       validate: validateProjectGoal,
     });

--- a/src/index.ts
+++ b/src/index.ts
@@ -3,6 +3,7 @@ import { initCommand } from "./commands/init";
 import { readFileSync } from "fs";
 import { fileURLToPath } from "url";
 import { dirname, join } from "path";
+import type { CLIOptions } from "./types.js";
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = dirname(__filename);
@@ -28,10 +29,35 @@ program
     "Path to initialize the project (defaults to current directory)",
     "."
   )
-  .action((path, options) => {
-    // Pass debug option to init command (default to false if not provided)
-    const debug = options.parent?.debug || false;
-    return initCommand(path, debug);
+  .option("--language <language>", "Programming language (python, typescript)")
+  .option("--framework <framework>", "Agent framework (agno, mastra, langgraph-py, langgraph-ts)")
+  .option("--llm-provider <provider>", "LLM provider (openai, anthropic, gemini, bedrock, openrouter, grok)")
+  .option("--llm-key <key>", "LLM API key")
+  .option("--langwatch-key <key>", "LangWatch API key")
+  .option("--coding-assistant <assistant>", "Coding assistant (claude-code, cursor, antigravity, kilocode, none)")
+  .option("--goal <goal>", "Project goal - what the agent should do")
+  .option("--aws-secret-key <key>", "AWS Secret Access Key (for Bedrock provider)")
+  .option("--aws-region <region>", "AWS Region (for Bedrock provider)", "us-east-1")
+  .option("-y, --yes", "Non-interactive mode (requires all options to be provided)")
+  .action((path, options, command) => {
+    // Get debug from parent command
+    const debug = command.parent?.opts()?.debug || false;
+
+    // Build CLI options object
+    const cliOptions: CLIOptions = {
+      language: options.language,
+      framework: options.framework,
+      llmProvider: options.llmProvider,
+      llmKey: options.llmKey,
+      langwatchKey: options.langwatchKey,
+      codingAssistant: options.codingAssistant,
+      goal: options.goal,
+      awsSecretKey: options.awsSecretKey,
+      awsRegion: options.awsRegion,
+      yes: options.yes,
+    };
+
+    return initCommand(path, cliOptions, debug);
   });
 
 program.parse();

--- a/src/types.ts
+++ b/src/types.ts
@@ -14,3 +14,22 @@ export type ProjectConfig = {
   projectGoal: string;
 };
 
+/**
+ * CLI options for non-interactive mode.
+ * When these are provided, the corresponding prompts are skipped.
+ */
+export type CLIOptions = {
+  language?: ProgrammingLanguage;
+  framework?: AgentFramework;
+  codingAssistant?: CodingAssistant;
+  llmProvider?: LLMProvider;
+  llmKey?: string;
+  langwatchKey?: string;
+  goal?: string;
+  /** Additional inputs for providers that need them (e.g., AWS credentials for Bedrock) */
+  awsSecretKey?: string;
+  awsRegion?: string;
+  /** If true, all required options must be provided (no prompts) */
+  yes?: boolean;
+};
+


### PR DESCRIPTION
Adds support for running better-agents init without interactive prompts by providing all required configuration via command-line flags. Enables automation and CI/CD use cases.

New CLI options: --language, --framework, --llm-provider, --llm-key, --langwatch-key, --coding-assistant, --goal, --aws-secret-key, --aws-region, -y/--yes

Generated with Claude Code