### PR TITLE
fix: add missing AI SDK framework option in documentation generation

### DIFF
--- a/src/documentation/sections/overview-section.ts
+++ b/src/documentation/sections/overview-section.ts
@@ -30,6 +30,8 @@ export const buildOverviewSection = ({ config }: { config: ProjectConfig }): str
     ? 'LangGraph (TypeScript)'
     : framework === 'google-adk'
     ? 'Google ADK'
+    : framework === 'vercel-ai'
+    ? 'Vercel AI SDK'
     : 'Mastra'
 }
 **Language:** ${language === 'python' ? 'Python' : 'TypeScript'}

--- a/src/documentation/sections/workflow-section.ts
+++ b/src/documentation/sections/workflow-section.ts
@@ -101,6 +101,8 @@ The MCP will provide up-to-date documentation and examples. For Scenario specifi
       ? '- **LangGraph.js Documentation**: Use the LangGraph MCP for up-to-date docs'
       : config.framework === 'google-adk'
       ? '- **Google ADK Documentation**: Use the Google ADK MCP for up-to-date docs'
+      : config.framework === 'vercel-ai'
+      ? '- **AI SDK Documentation**: Use the AI SDK MCP for up-to-date docs'
       : '- **Mastra Documentation**: Use the Mastra MCP for up-to-date docs'}
 
 ---


### PR DESCRIPTION
## Problem
When creating an agent with `vercel-ai` as the framework, the documentation generator was defaulting to "Mastra" because the `vercel-ai` option was missing from the conditional chains. This caused code assistants to install Mastra even though Vercel AI SDK was selected.

## Solution
Added the missing `vercel-ai` framework conditions in:
- `overview-section.ts` - to display the correct framework name
- `workflow-section.ts` - to reference the correct documentation

## Testing
- Tested with `vercel-ai` framework, now it displays "Vercel AI SDK" (overview) and "AI SDK Documentation" (workflow) instead of "Mastra"
- Verified other frameworks (mastra, langgraph, google-adk) still work correctly