### PR TITLE
feat: pass LANGWATCH_API_KEY to MCP server config

### DIFF
--- a/src/assistant-kickoff/build-initial-prompt.ts
+++ b/src/assistant-kickoff/build-initial-prompt.ts
@@ -32,7 +32,7 @@ export const buildInitialPrompt = ({
 First steps:
 1. Read and understand the AGENTS.md file - it contains all the guidelines for this project
 2. Update the AGENTS.md with specific details about what this project does
-3. Create a comprehensive README.md explaining the project, setup, and usage
+3. Create a comprehensive README.md explaining the project, setup, and usage. Include instructions for new developers to copy .env.example to .env and .mcp.json.example to .mcp.json, filling in their own API keys
 4. Set up the ${languageKnowledge.setupInstructions}
 5. ${frameworkKnowledge.toolingInstructions}
 6. Execute any installation steps needed yourself, for the library dependencies, the CLI tools, etc

--- a/src/builders/cli-config-builder.ts
+++ b/src/builders/cli-config-builder.ts
@@ -86,7 +86,7 @@ export const setupCLIConfigs = async ({
     for (const [key, server] of Object.entries(mcpConfig.mcpServers)) {
       if (typeof server === "object" && server !== null) {
         // If it already has a type, use it; otherwise default to "stdio"
-        const serverConfig = server as { type?: string; command?: string; args?: string[]; transport?: string; url?: string };
+        const serverConfig = server as { type?: string; command?: string; args?: string[]; env?: Record<string, string>; transport?: string; url?: string };
         
         if ("type" in serverConfig && serverConfig.type === "http") {
           // HTTP transport
@@ -97,11 +97,15 @@ export const setupCLIConfigs = async ({
           };
         } else {
           // stdio transport (default)
-          crushMCP[key] = {
+          const stdioConfig: Record<string, unknown> = {
             type: "stdio",
             command: serverConfig.command,
             args: serverConfig.args || [],
           };
+          if (serverConfig.env) {
+            stdioConfig.env = serverConfig.env;
+          }
+          crushMCP[key] = stdioConfig;
         }
       }
     }

--- a/src/builders/editor-setup-builder.ts
+++ b/src/builders/editor-setup-builder.ts
@@ -39,6 +39,17 @@ export const setupEditorConfigs = async ({
   const mcpConfigPath = path.join(projectPath, ".mcp.json");
   await fs.writeFile(mcpConfigPath, JSON.stringify(mcpConfig, null, 2));
 
+  // 1b. Write .mcp.json.example with placeholder API key (committed to git)
+  const mcpConfigExample = JSON.parse(JSON.stringify(mcpConfig)) as MCPConfigFile;
+  if (mcpConfigExample.mcpServers.langwatch && "env" in mcpConfigExample.mcpServers.langwatch) {
+    const langwatch = mcpConfigExample.mcpServers.langwatch as { env?: Record<string, string> };
+    if (langwatch.env?.LANGWATCH_API_KEY) {
+      langwatch.env.LANGWATCH_API_KEY = "your_langwatch_api_key_here";
+    }
+  }
+  const mcpExamplePath = path.join(projectPath, ".mcp.json.example");
+  await fs.writeFile(mcpExamplePath, JSON.stringify(mcpConfigExample, null, 2));
+
   // 2. Create .cursor directory and symlink to root .mcp.json
   const cursorDir = path.join(projectPath, ".cursor");
   await fs.mkdir(cursorDir, { recursive: true });

--- a/src/builders/mcp-config-builder.ts
+++ b/src/builders/mcp-config-builder.ts
@@ -28,6 +28,9 @@ export const buildMCPConfig = ({
   mcpConfig.mcpServers.langwatch = {
     command: "npx",
     args: ["-y", "@langwatch/mcp-server"],
+    env: {
+      LANGWATCH_API_KEY: config.langwatchApiKey,
+    },
   };
 
   // Add framework-specific MCP if available

--- a/src/config-collection/collect-config.ts
+++ b/src/config-collection/collect-config.ts
@@ -1,4 +1,5 @@
 import { select, input, password, confirm } from "@inquirer/prompts";
+import { textarea } from "./prompts/textarea.js";
 import { spawn } from "child_process";
 import type {
   ProjectConfig,
@@ -408,7 +409,7 @@ export const collectConfig = async (
 
     logger.userInfo("✔︎ Your coding assistant will finish setup later if needed\n");
 
-    const projectGoal: string = cliOptions.goal || await input({
+    const projectGoal: string = cliOptions.goal || await textarea({
       message: "What is your agent going to do?",
       validate: validateProjectGoal,
     });

--- a/src/config-collection/prompts/textarea.ts
+++ b/src/config-collection/prompts/textarea.ts
@@ -23,7 +23,7 @@ export async function textarea(config: TextareaConfig): Promise<string> {
     stdin.setRawMode(true);
     stdin.resume();
 
-    let lines: string[] = [""];
+    const lines: string[] = [""];
     let cursorLine = 0;
     let cursorCol = 0;
     let isPasting = false;
@@ -183,6 +183,7 @@ export async function textarea(config: TextareaConfig): Promise<string> {
         }
         // Arrow keys and other CSI sequences
         if (str.startsWith("\x1b[", i)) {
+          // eslint-disable-next-line no-control-regex
           const seqMatch = str.slice(i).match(/^\x1b\[[0-9;]*[A-Za-z~]/);
           if (seqMatch) {
             const seq = seqMatch[0];

--- a/src/config-collection/prompts/textarea.ts
+++ b/src/config-collection/prompts/textarea.ts
@@ -1,0 +1,270 @@
+import chalk from "chalk";
+
+type TextareaConfig = {
+  message: string;
+  validate?: (value: string) => boolean | string | Promise<boolean | string>;
+};
+
+const PASTE_START = "\x1b[200~";
+const PASTE_END = "\x1b[201~";
+// Shift+Enter in CSI u encoding (kitty keyboard protocol)
+const SHIFT_ENTER_CSI_U = "\x1b[13;2u";
+// Shift+Enter in some terminals
+const SHIFT_ENTER_MOD = "\x1b[27;2;13~";
+
+export async function textarea(config: TextareaConfig): Promise<string> {
+  const { message, validate = () => true } = config;
+
+  return new Promise<string>((resolve, reject) => {
+    const stdin = process.stdin;
+    const stdout = process.stdout;
+
+    const wasRaw = stdin.isRaw;
+    stdin.setRawMode(true);
+    stdin.resume();
+
+    let lines: string[] = [""];
+    let cursorLine = 0;
+    let cursorCol = 0;
+    let isPasting = false;
+    let errorMsg: string | undefined;
+    let renderedLineCount = 0;
+
+    // Enable bracketed paste mode
+    stdout.write("\x1b[?2004h");
+
+    function cleanup() {
+      stdout.write("\x1b[?2004l");
+      stdin.setRawMode(wasRaw ?? false);
+      stdin.removeListener("data", onData);
+      stdin.pause();
+    }
+
+    function clearRendered() {
+      // Move cursor to start of rendered area and clear
+      if (renderedLineCount > 0) {
+        // Move up to the first rendered line
+        if (renderedLineCount > 1) {
+          stdout.write(`\x1b[${renderedLineCount - 1}A`);
+        }
+        stdout.write("\r");
+        // Clear from cursor to end of screen
+        stdout.write("\x1b[J");
+      }
+    }
+
+    function render() {
+      clearRendered();
+
+      const prefix = chalk.green("?");
+      const hint = chalk.dim("(Shift+Enter for new line)");
+      const header = `${prefix} ${chalk.bold(message)} ${hint}`;
+
+      const contentLines = lines.map((line) => `  ${line}`);
+
+      const output = [header, ...contentLines];
+      if (errorMsg) {
+        output.push(chalk.red(`> ${errorMsg}`));
+      }
+
+      stdout.write(output.join("\n"));
+      renderedLineCount = output.length;
+
+      // Position cursor on the active line
+      // The cursor should be at line (1 + cursorLine) from the header, col (2 + cursorCol) for the indent
+      const linesFromBottom = contentLines.length - 1 - cursorLine + (errorMsg ? 1 : 0);
+      if (linesFromBottom > 0) {
+        stdout.write(`\x1b[${linesFromBottom}A`);
+      }
+      stdout.write(`\r\x1b[${2 + cursorCol}C`);
+    }
+
+    function renderDone(value: string) {
+      clearRendered();
+      const prefix = chalk.green("✔");
+      const displayLines = value.split("\n");
+      const summary =
+        displayLines.length > 1
+          ? `${displayLines[0]} ${chalk.dim(`(+${displayLines.length - 1} more lines)`)}`
+          : displayLines[0];
+      stdout.write(`${prefix} ${chalk.bold(message)} ${chalk.cyan(summary ?? "")}\n`);
+    }
+
+    function insertText(text: string) {
+      for (const ch of text) {
+        if (ch === "\n" || ch === "\r") {
+          // Split current line at cursor
+          const before = lines[cursorLine]!.slice(0, cursorCol);
+          const after = lines[cursorLine]!.slice(cursorCol);
+          lines[cursorLine] = before;
+          lines.splice(cursorLine + 1, 0, after);
+          cursorLine++;
+          cursorCol = 0;
+        } else if (ch >= " ") {
+          // Insert character at cursor position
+          const line = lines[cursorLine]!;
+          lines[cursorLine] = line.slice(0, cursorCol) + ch + line.slice(cursorCol);
+          cursorCol++;
+        }
+      }
+    }
+
+    function handleBackspace() {
+      if (cursorCol > 0) {
+        const line = lines[cursorLine]!;
+        lines[cursorLine] = line.slice(0, cursorCol - 1) + line.slice(cursorCol);
+        cursorCol--;
+      } else if (cursorLine > 0) {
+        // Merge with previous line
+        const currentContent = lines[cursorLine]!;
+        lines.splice(cursorLine, 1);
+        cursorLine--;
+        cursorCol = lines[cursorLine]!.length;
+        lines[cursorLine] += currentContent;
+      }
+    }
+
+    function handleDelete() {
+      const line = lines[cursorLine]!;
+      if (cursorCol < line.length) {
+        lines[cursorLine] = line.slice(0, cursorCol) + line.slice(cursorCol + 1);
+      } else if (cursorLine < lines.length - 1) {
+        // Merge next line into current
+        lines[cursorLine] += lines[cursorLine + 1]!;
+        lines.splice(cursorLine + 1, 1);
+      }
+    }
+
+    async function submit() {
+      const value = lines.join("\n");
+      const isValid = await validate(value);
+      if (isValid === true) {
+        cleanup();
+        renderDone(value);
+        resolve(value);
+      } else {
+        errorMsg =
+          typeof isValid === "string"
+            ? isValid
+            : "You must provide a valid value";
+        render();
+      }
+    }
+
+    function onData(data: Buffer) {
+      const str = data.toString();
+      errorMsg = undefined;
+
+      let i = 0;
+      while (i < str.length) {
+        // Bracketed paste start
+        if (str.startsWith(PASTE_START, i)) {
+          isPasting = true;
+          i += PASTE_START.length;
+          continue;
+        }
+        // Bracketed paste end
+        if (str.startsWith(PASTE_END, i)) {
+          isPasting = false;
+          i += PASTE_END.length;
+          continue;
+        }
+        // Shift+Enter (CSI u / kitty protocol)
+        if (str.startsWith(SHIFT_ENTER_CSI_U, i)) {
+          insertText("\n");
+          i += SHIFT_ENTER_CSI_U.length;
+          continue;
+        }
+        // Shift+Enter (modified key format)
+        if (str.startsWith(SHIFT_ENTER_MOD, i)) {
+          insertText("\n");
+          i += SHIFT_ENTER_MOD.length;
+          continue;
+        }
+        // Arrow keys and other CSI sequences
+        if (str.startsWith("\x1b[", i)) {
+          const seqMatch = str.slice(i).match(/^\x1b\[[0-9;]*[A-Za-z~]/);
+          if (seqMatch) {
+            const seq = seqMatch[0];
+            const code = seq[seq.length - 1];
+            if (code === "A") {
+              // Up arrow
+              if (cursorLine > 0) {
+                cursorLine--;
+                cursorCol = Math.min(cursorCol, lines[cursorLine]!.length);
+              }
+            } else if (code === "B") {
+              // Down arrow
+              if (cursorLine < lines.length - 1) {
+                cursorLine++;
+                cursorCol = Math.min(cursorCol, lines[cursorLine]!.length);
+              }
+            } else if (code === "C") {
+              // Right arrow
+              if (cursorCol < lines[cursorLine]!.length) {
+                cursorCol++;
+              } else if (cursorLine < lines.length - 1) {
+                cursorLine++;
+                cursorCol = 0;
+              }
+            } else if (code === "D") {
+              // Left arrow
+              if (cursorCol > 0) {
+                cursorCol--;
+              } else if (cursorLine > 0) {
+                cursorLine--;
+                cursorCol = lines[cursorLine]!.length;
+              }
+            } else if (code === "H") {
+              // Home
+              cursorCol = 0;
+            } else if (code === "F") {
+              // End
+              cursorCol = lines[cursorLine]!.length;
+            } else if (seq === "\x1b[3~") {
+              // Delete key
+              handleDelete();
+            }
+            i += seq.length;
+            continue;
+          }
+        }
+        // Skip other escape sequences
+        if (str[i] === "\x1b") {
+          i++;
+          continue;
+        }
+
+        const ch = str[i]!;
+
+        if (ch === "\r" || ch === "\n") {
+          if (isPasting) {
+            insertText("\n");
+          } else {
+            // Submit
+            render();
+            void submit();
+            return;
+          }
+        } else if (ch === "\x7f" || ch === "\x08") {
+          // Backspace
+          handleBackspace();
+        } else if (ch === "\x03") {
+          // Ctrl+C
+          cleanup();
+          reject(new Error("User aborted"));
+          return;
+        } else if (ch >= " ") {
+          insertText(ch);
+        }
+
+        i++;
+      }
+
+      render();
+    }
+
+    stdin.on("data", onData);
+    render();
+  });
+}

--- a/src/config-collection/prompts/textarea.ts
+++ b/src/config-collection/prompts/textarea.ts
@@ -237,15 +237,18 @@ export async function textarea(config: TextareaConfig): Promise<string> {
 
         const ch = str[i]!;
 
-        if (ch === "\r" || ch === "\n") {
+        if (ch === "\r") {
           if (isPasting) {
             insertText("\n");
           } else {
-            // Submit
+            // Enter (\r) = submit
             render();
             void submit();
             return;
           }
+        } else if (ch === "\n") {
+          // Shift+Enter (\n) or newline during paste
+          insertText("\n");
         } else if (ch === "\x7f" || ch === "\x08") {
           // Backspace
           handleBackspace();

--- a/src/project-scaffolding/file-generators/gitignore-generator.ts
+++ b/src/project-scaffolding/file-generators/gitignore-generator.ts
@@ -30,6 +30,10 @@ build/
 
 # Better Agents
 .better-agents/
+
+# MCP config (contains API keys, use .mcp.json.example as template)
+.mcp.json
+.cursor/mcp.json
 `;
 
 /**
@@ -63,6 +67,16 @@ export const ensureGitignore = async ({
       const appendContent = `
 # Better Agents
 .better-agents/
+`;
+      await fs.appendFile(gitignorePath, appendContent);
+    }
+
+    // Check if .mcp.json is already ignored
+    if (!existingContent.includes(".mcp.json")) {
+      const appendContent = `
+# MCP config (contains API keys, use .mcp.json.example as template)
+.mcp.json
+.cursor/mcp.json
 `;
       await fs.appendFile(gitignorePath, appendContent);
     }

--- a/src/providers/coding-assistants/index.ts
+++ b/src/providers/coding-assistants/index.ts
@@ -15,6 +15,7 @@ export type MCPConfigFile = {
         type?: "stdio";
         command: string;
         args?: string[];
+        env?: Record<string, string>;
       }
     | {
         type: "http";

--- a/src/providers/coding-assistants/index.ts
+++ b/src/providers/coding-assistants/index.ts
@@ -56,12 +56,11 @@ export interface CodingAssistantProvider {
 }
 
 const PROVIDERS: Record<CodingAssistant, CodingAssistantProvider> = {
-  kilocode: KilocodeCodingAssistantProvider,
   "claude-code": ClaudeCodingAssistantProvider,
   cursor: CursorCodingAssistantProvider,
+  kilocode: KilocodeCodingAssistantProvider,
   antigravity: AntigravityCodingAssistantProvider,
-  
-    crush: CrushCodingAssistantProvider,
+  crush: CrushCodingAssistantProvider,
   'gemini-cli': GeminiCLICodingAssistantProvider,
   'qwen-code': QwenCodeCodingAssistantProvider,
   none: NoneCodingAssistantProvider,


### PR DESCRIPTION
## Summary
- Pass `LANGWATCH_API_KEY` via the `env` field in the LangWatch MCP server config, as required by the [updated docs](https://langwatch.ai/docs/integration/mcp)
- Gitignore `.mcp.json` (and `.cursor/mcp.json`) since it now contains API key secrets
- Generate a `.mcp.json.example` with placeholder values so the config shape is committed for team reference
- Update the initial prompt to instruct the coding agent to include `.mcp.json.example` copy instructions in the project README
- Replace single-line input for project goal with a custom raw-stdin **textarea prompt** that supports:
  - **Shift+Enter** for newlines (detects `\n` vs `\r` — works in Warp and other terminals)
  - **Bracketed paste mode** for pasting multiline text without submitting
  - Arrow key navigation, backspace across lines, Home/End, Delete
  - CSI u / kitty keyboard protocol support for Shift+Enter
- Reorder coding assistant choices: move Kilocode after Cursor

## Test plan
- [x] Run `better-agents init` and verify `.mcp.json` contains the real API key in `env.LANGWATCH_API_KEY`
- [x] Verify `.mcp.json.example` is generated with `"your_langwatch_api_key_here"` placeholder
- [x] Verify `.gitignore` includes `.mcp.json` and `.cursor/mcp.json`
- [x] Verify the LangWatch MCP server connects successfully with the new config format
- [x] Run init on a project with an existing `.gitignore` and confirm `.mcp.json` entry is appended
- [x] Test textarea: type single line + Enter → submits
- [x] Test textarea: Shift+Enter → adds newline, continues editing
- [x] Test textarea: paste multiline text → all lines appear, no premature submit
- [x] Test textarea: backspace on empty line → merges with previous line
- [x] Test textarea: empty input + Enter → validation error shows
- [x] Verify coding assistant list shows Kilocode after Cursor