### PR TITLE
fix: use PAT for release-please to trigger publish workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -4,7 +4,6 @@ on:
   release:
     types: [published]
   workflow_dispatch:
-  workflow_call:
 
 permissions:
   id-token: write
@@ -43,8 +42,7 @@ jobs:
     needs: check
     if: |
       (github.event_name == 'release' && startsWith(github.event.release.tag_name, 'v')) ||
-      (github.event_name == 'workflow_dispatch' && github.ref == 'refs/heads/main') ||
-      (github.event_name == 'workflow_call')
+      (github.event_name == 'workflow_dispatch' && github.ref == 'refs/heads/main')
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -1,4 +1,4 @@
-name: Release Please
+name: release-please
 
 on:
   push:
@@ -7,46 +7,19 @@ on:
   workflow_dispatch:
 
 permissions:
-  issues: write # This is important for label creation
   contents: write
   pull-requests: write
-  id-token: write # Required for OIDC publishing in called workflow
 
 jobs:
   release-please:
     runs-on: ubuntu-latest
-    outputs:
-      # Don't use release_created this: https://danwakeem.medium.com/beware-the-release-please-v4-github-action-ee71ff9de151
-      # releases_created: ${{ steps.release.outputs.releases_created }}
-      # paths_released: ${{ steps.release.outputs.paths_released }}
-      release_created: ${{ steps.release.outputs.release_created }}
-      tag_name: ${{ steps.release.outputs.tag_name }}
     steps:
-      - uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
       - uses: googleapis/release-please-action@v4
         id: release
         with:
-          # Use manifest mode for monorepo
+          # Use a PAT so that the created releases trigger downstream
+          # workflows (release: published). The default GITHUB_TOKEN does
+          # not trigger other workflows — this is a GitHub limitation.
+          token: ${{ secrets.RELEASE_PLEASE_TOKEN }}
           config-file: .release-please-config.json
           manifest-file: .release-please-manifest.json
-
-  # Debug job to echo release-please outputs
-  debug-outputs:
-    needs: release-please
-    runs-on: ubuntu-latest
-    steps:
-      - name: Echo outputs
-        shell: bash
-        env:
-          RELEASE_OUTPUTS: ${{ toJSON(needs.release-please.outputs) }}
-        run: |
-          echo "All release-please outputs:"
-          printf '%s\n' "$RELEASE_OUTPUTS"
-
-  # Call the Release workflow as a job
-  trigger-publish:
-    if: ${{ needs.release-please.outputs.release_created }}
-    needs: release-please
-    uses: ./.github/workflows/publish.yml


### PR DESCRIPTION
## Summary
- Use `RELEASE_PLEASE_TOKEN` PAT instead of default `GITHUB_TOKEN` for release-please, so that created GitHub Releases trigger the `release: published` event for the publish workflow
- Remove the `trigger-publish` and `debug-outputs` workaround jobs from release-please.yml
- Remove `workflow_call` trigger from publish.yml (no longer needed)

This is the same fix applied to the [scenario repo](https://github.com/langwatch/scenario). The default `GITHUB_TOKEN` is a GitHub limitation — events created by it don't trigger other workflows.

## Prerequisites
- [x] Ensure `RELEASE_PLEASE_TOKEN` secret is set in the repo settings (a GitHub PAT with `contents: write` and `pull-requests: write` permissions)

## Test plan
- [ ] Merge this PR, then merge the release-please PR it creates
- [ ] Verify the publish workflow triggers automatically from the release event