### PR TITLE
fix: patch fast-uri to >=3.1.2 for path traversal and host confusion vulnerabilities

### DIFF
--- a/package.json
+++ b/package.json
@@ -86,7 +86,8 @@
       "flatted": ">=3.4.2",
       "minimatch": ">=9.0.7",
       "rollup": ">=4.59.0",
-      "axios": ">=1.13.5"
+      "axios": ">=1.13.5",
+      "fast-uri": ">=3.1.2"
     }
   },
   "devDependencies": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -10,6 +10,7 @@ overrides:
   minimatch: '>=9.0.7'
   rollup: '>=4.59.0'
   axios: '>=1.13.5'
+  fast-uri: '>=3.1.2'
 
 importers:
 
@@ -1393,8 +1394,8 @@ packages:
   fast-safe-stringify@2.1.1:
     resolution: {integrity: sha512-W+KJc2dmILlPplD/H4K9l9LcAHAfPtP6BY84uVLXQ6Evcz9Lcg33Y2z1IVblT6xdY54PXYVHEv+0Wpq8Io6zkA==}
 
-  fast-uri@3.1.0:
-    resolution: {integrity: sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA==}
+  fast-uri@3.1.2:
+    resolution: {integrity: sha512-rVjf7ArG3LTk+FS6Yw81V1DLuZl1bRbNrev6Tmd/9RaroeeRRJhAt7jg/6YFxbvAQXUCavSoZhPPj6oOx+5KjQ==}
 
   fastq@1.19.1:
     resolution: {integrity: sha512-GwLTyxkCXjXbxqIhTsMI2Nui8huMPtnxg7krajPJAjnEG/iiOS7i+zCtWGZR9G0NBKbXKh6X9m9UIsYX/N6vvQ==}
@@ -3109,7 +3110,7 @@ snapshots:
   ajv@8.17.1:
     dependencies:
       fast-deep-equal: 3.1.3
-      fast-uri: 3.1.0
+      fast-uri: 3.1.2
       json-schema-traverse: 1.0.0
       require-from-string: 2.0.2
 
@@ -3489,7 +3490,7 @@ snapshots:
 
   fast-safe-stringify@2.1.1: {}
 
-  fast-uri@3.1.0: {}
+  fast-uri@3.1.2: {}
 
   fastq@1.19.1:
     dependencies:


### PR DESCRIPTION
## Summary
- Adds pnpm override for `fast-uri >= 3.1.2` to resolve two high-severity Dependabot alerts
- **#122**: path traversal via percent-encoded dot segments (fixed in 3.1.1)
- **#123**: host confusion via percent-encoded authority delimiters (fixed in 3.1.2)

## Test plan
- [x] `pnpm install` succeeds and lockfile shows `fast-uri@3.1.2`
- [x] All existing tests pass (`vitest --run`)